### PR TITLE
feat(prefect executor): v1 for sandbox use

### DIFF
--- a/infra/pipelines/docker/Dockerfile
+++ b/infra/pipelines/docker/Dockerfile
@@ -1,10 +1,17 @@
-FROM prefecthq/prefect
+FROM graphistry/graphistry-blazing:v2.29.3
 
-RUN pip install supervisor arrow graphistry pyarrow simplejson twarc neo4j
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends supervisor \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install prefect==0.10.1 simplejson twarc neo4j
 RUN prefect agent install local > supervisord.conf
 
 COPY . .
+
+#TODO find cleaner way to avoid talking to cloud server
 RUN prefect backend server
 
-RUN date > /dev/null
 CMD ["./infra/pipelines/docker/entrypoint.sh"]

--- a/infra/pipelines/docker/Dockerfile
+++ b/infra/pipelines/docker/Dockerfile
@@ -6,12 +6,13 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install prefect==0.10.1 simplejson twarc neo4j boto3==1.12.39
-RUN prefect agent install local > supervisord.conf
+RUN source activate rapids \
+    && pip install prefect==0.10.1 simplejson twarc neo4j boto3==1.12.39 \
+    && ( prefect agent install local > supervisord.conf )
 
 COPY . .
 
 #TODO find cleaner way to avoid talking to cloud server
-RUN prefect backend server
+RUN source activate rapids && prefect backend server
 
 CMD ["./infra/pipelines/docker/entrypoint.sh"]

--- a/infra/pipelines/docker/Dockerfile
+++ b/infra/pipelines/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install prefect==0.10.1 simplejson twarc neo4j
+RUN pip install prefect==0.10.1 simplejson twarc neo4j boto3==1.12.39
 RUN prefect agent install local > supervisord.conf
 
 COPY . .

--- a/infra/pipelines/docker/docker-compose.yml
+++ b/infra/pipelines/docker/docker-compose.yml
@@ -1,0 +1,26 @@
+########
+#
+# Run from git root's parent: with .env in local folder and ProjectDomino/ inside
+#
+# $ touch .env
+# $ sudo docker-compose -f ./ProjectDomino/infra/pipelines/docker/docker-compose.yml up -d prefect-agent
+#
+########
+
+version: '3.4'
+
+services:
+  prefect-agent:
+    image: neo4j:4.0.2-enterprise
+    build:
+      context: ../../../
+      dockerfile: ./infra/pipelines/docker/Dockerfile
+    container_name: prefect-agent
+    network_mode: 'bridge'
+    restart: unless-stopped
+    environment:
+      PREFECT__SERVER__HOST: ${PREFECT__SERVER__HOST:-http://host.docker.internal}
+      PREFECT__SERVER__PORT: ${PREFECT__SERVER__PORT:-4200}
+    logging:
+      options:
+        tag: 'ImageName:{{.ImageName}}/Name:{{.Name}}/ID:{{.ID}}/ImageFullID:{{.ImageFullID}}'

--- a/infra/pipelines/docker/docker-compose.yml
+++ b/infra/pipelines/docker/docker-compose.yml
@@ -11,7 +11,7 @@ version: '3.4'
 
 services:
   prefect-agent:
-    image: neo4j:4.0.2-enterprise
+    image:  prefect-agent:0.0.3
     build:
       context: ../../../
       dockerfile: ./infra/pipelines/docker/Dockerfile

--- a/infra/pipelines/docker/docker-compose.yml
+++ b/infra/pipelines/docker/docker-compose.yml
@@ -11,7 +11,7 @@ version: '3.4'
 
 services:
   prefect-agent:
-    image:  prefect-agent:0.0.3
+    image:  prefect-agent:0.0.5
     build:
       context: ../../../
       dockerfile: ./infra/pipelines/docker/Dockerfile
@@ -23,6 +23,8 @@ services:
       PREFECT__SERVER__PORT: ${PREFECT__SERVER__PORT:-4200}
       PREFECT__SERVER__UI__HOST: ${PREFECT__SERVER__UI__HOST:-http://host.docker.internal}
       PREFECT__SERVER__UI__PORT: ${PREFECT__SERVER__UI__PORT:-8080}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
     logging:
       options:
         tag: 'ImageName:{{.ImageName}}/Name:{{.Name}}/ID:{{.ID}}/ImageFullID:{{.ImageFullID}}'

--- a/infra/pipelines/docker/docker-compose.yml
+++ b/infra/pipelines/docker/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     environment:
       PREFECT__SERVER__HOST: ${PREFECT__SERVER__HOST:-http://host.docker.internal}
       PREFECT__SERVER__PORT: ${PREFECT__SERVER__PORT:-4200}
+      PREFECT__SERVER__UI__HOST: ${PREFECT__SERVER__UI__HOST:-http://host.docker.internal}
+      PREFECT__SERVER__UI__PORT: ${PREFECT__SERVER__UI__PORT:-8080}
     logging:
       options:
         tag: 'ImageName:{{.ImageName}}/Name:{{.Name}}/ID:{{.ID}}/ImageFullID:{{.ImageFullID}}'

--- a/infra/pipelines/docker/entrypoint.sh
+++ b/infra/pipelines/docker/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Starting prefect executor daemon in foreground"
-supervisord --nodaemon
+source activate rapids && supervisord --nodaemon

--- a/infra/pipelines/docker/entrypoint.sh
+++ b/infra/pipelines/docker/entrypoint.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
 
-# Run prefect agent using supervisord
-# supervisord
-
-# Register pipelines
-# git fetch && git checkout wzy/dockerizePipelines
-
-python -m pipelines.Pipeline
-
-# Keep the container running
-prefect agent start
+echo "Starting prefect executor daemon in foreground"
+supervisord --nodaemon


### PR DESCRIPTION
Adds initial docker-compose for operating a prefect executor

![image](https://user-images.githubusercontent.com/4249447/79031304-c15f3b80-7b52-11ea-9cbd-8438e382662e.png)


Use from `ProjectDomino` parent folder:

```
echo "PREFECT__SERVER__HOST=PREFECT.SERVER.IP.HERE" > .env

sudo docker-compose -f ./ProjectDomino/infra/pipelines/docker/docker-compose.yml up -d prefect-agent

sudo docker ps
```

Next:
-- Change `Dockerfile` to be a layer off `graphistry-blazing` + whatever else we add
-- Healthcheck + prometheus hook
