### PR TITLE
WIP: Twint

### DIFF
--- a/modules/Neo4jDataAccess.py
+++ b/modules/Neo4jDataAccess.py
@@ -3,18 +3,35 @@ import json
 import time
 import re
 
+import enum
+
 from datetime import datetime
 import pandas as pd
 from neo4j import GraphDatabase, basic_auth
 from urllib.parse import urlparse
 import logging
-
 from .DfHelper import DfHelper
 
 logger = logging.getLogger('Neo4jDataAccess')
 
 
 class Neo4jDataAccess:
+    class NodeLabel(enum.Enum):
+        Tweet = 'Tweet'
+        Url = 'Url'
+        Account = 'Account'
+
+    class RelationshipLabel(enum.Enum):
+        TWEETED = 'TWEETED'
+        MENTIONED = 'MENTIONED'
+        QUOTED = 'QUOTED'
+        REPLIED = 'REPLIED'
+        RETWEETED = 'RETWEETED'
+        INCLUDES = 'INCLUDES'
+
+    class RoleType(enum.Enum):
+        READER = 'reader'
+        WRITER = 'writer'
 
     def __init__(self, debug=False, neo4j_creds=None, batch_size=2000, timeout="60s"):
         self.creds = neo4j_creds
@@ -23,9 +40,9 @@ class Neo4jDataAccess:
         self.batch_size = batch_size
         self.tweetsandaccounts = """
                   UNWIND $tweets AS t
-                      //Add the Tweet 
+                      //Add the Tweet
                     MERGE (tweet:Tweet {id:t.tweet_id})
-                        ON CREATE SET 
+                        ON CREATE SET
                             tweet.text = t.text,
                             tweet.created_at = t.tweet_created_at,
                             tweet.favorite_count = t.favorite_count,
@@ -36,7 +53,7 @@ class Neo4jDataAccess:
                             tweet.hashtags = t.hashtags,
                             tweet.hydrated = 'FULL',
                             tweet.type = t.tweet_type
-                        ON MATCH SET 
+                        ON MATCH SET
                             tweet.text = t.text,
                             tweet.favorite_count = t.favorite_count,
                             tweet.retweet_count = t.retweet_count,
@@ -46,10 +63,10 @@ class Neo4jDataAccess:
                             tweet.hashtags = t.hashtags,
                             tweet.hydrated = 'FULL',
                             tweet.type = t.tweet_type
-                    
+
                     //Add Account
-                    MERGE (user:Account {id:t.user_id})                    
-                        ON CREATE SET 
+                    MERGE (user:Account {id:t.user_id})
+                        ON CREATE SET
                             user.id = t.user_id,
                             user.name = t.name,
                             user.screen_name = t.user_screen_name,
@@ -61,7 +78,7 @@ class Neo4jDataAccess:
                             user.record_created_at = timestamp(),
                             user.job_name = t.job_name,
                             user.job_id = t.job_id
-                        ON MATCH SET 
+                        ON MATCH SET
                             user.name = t.user_name,
                             user.screen_name = t.user_screen_name,
                             user.followers_count = t.user_followers_count,
@@ -71,31 +88,31 @@ class Neo4jDataAccess:
                             user.created_at = t.user_created_at,
                             user.record_updated_at = timestamp(),
                             user.job_name = t.job_name,
-                            user.job_id = t.job_id                  
+                            user.job_id = t.job_id
 
                     //Add Reply to tweets if needed
-                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='REPLY' THEN [1] ELSE [] END | 
-                        MERGE (retweet:Tweet {id:t.reply_tweet_id})            
+                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='REPLY' THEN [1] ELSE [] END |
+                        MERGE (retweet:Tweet {id:t.reply_tweet_id})
                             ON CREATE SET retweet.id=t.reply_tweet_id,
                             retweet.record_created_at = timestamp(),
                             retweet.job_name = t.job_name,
                             retweet.job_id = t.job_id,
                             retweet.hydrated = 'PARTIAL'
                     )
-                    
+
                     //Add QUOTE_RETWEET to tweets if needed
-                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='QUOTE_RETWEET' THEN [1] ELSE [] END | 
-                        MERGE (quoteTweet:Tweet {id:t.quoted_status_id})            
+                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='QUOTE_RETWEET' THEN [1] ELSE [] END |
+                        MERGE (quoteTweet:Tweet {id:t.quoted_status_id})
                             ON CREATE SET quoteTweet.id=t.quoted_status_id,
                             quoteTweet.record_created_at = timestamp(),
                             quoteTweet.job_name = t.job_name,
                             quoteTweet.job_id = t.job_id,
                             quoteTweet.hydrated = 'PARTIAL'
                     )
-                    
+
                     //Add RETWEET to tweets if needed
-                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='RETWEET' THEN [1] ELSE [] END | 
-                        MERGE (retweet:Tweet {id:t.retweet_id})            
+                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='RETWEET' THEN [1] ELSE [] END |
+                        MERGE (retweet:Tweet {id:t.retweet_id})
                             ON CREATE SET retweet.id=t.retweet_id,
                             retweet.record_created_at = timestamp(),
                             retweet.job_name = t.job_name,
@@ -106,70 +123,70 @@ class Neo4jDataAccess:
 
         self.tweeted_rel = """UNWIND $tweets AS t
                     MATCH (user:Account {id:t.user_id})
-                    MATCH (tweet:Tweet {id:t.tweet_id})  
-                    OPTIONAL MATCH (replied:Tweet {id:t.reply_tweet_id})     
-                    OPTIONAL MATCH (quoteTweet:Tweet {id:t.quoted_status_id})    
-                    OPTIONAL MATCH (retweet:Tweet {id:t.retweet_id})   
+                    MATCH (tweet:Tweet {id:t.tweet_id})
+                    OPTIONAL MATCH (replied:Tweet {id:t.reply_tweet_id})
+                    OPTIONAL MATCH (quoteTweet:Tweet {id:t.quoted_status_id})
+                    OPTIONAL MATCH (retweet:Tweet {id:t.retweet_id})
                     WITH user, tweet, replied, quoteTweet, retweet
-                                        
+
                     MERGE (user)-[r:TWEETED]->(tweet)
-                    
-                    FOREACH(ignoreMe IN CASE WHEN tweet.type='REPLY' AND replied.id>0 THEN [1] ELSE [] END | 
+
+                    FOREACH(ignoreMe IN CASE WHEN tweet.type='REPLY' AND replied.id>0 THEN [1] ELSE [] END |
                         MERGE (tweet)-[:REPLYED]->(replied)
                     )
-                    
-                    FOREACH(ignoreMe IN CASE WHEN tweet.type='QUOTE_RETWEET' AND quoteTweet.id>0 THEN [1] ELSE [] END | 
+
+                    FOREACH(ignoreMe IN CASE WHEN tweet.type='QUOTE_RETWEET' AND quoteTweet.id>0 THEN [1] ELSE [] END |
                         MERGE (tweet)-[:QUOTED]->(quoteTweet)
                     )
-                    
-                    FOREACH(ignoreMe IN CASE WHEN tweet.type='RETWEET' AND retweet.id>0 THEN [1] ELSE [] END | 
+
+                    FOREACH(ignoreMe IN CASE WHEN tweet.type='RETWEET' AND retweet.id>0 THEN [1] ELSE [] END |
                         MERGE (tweet)-[:RETWEETED]->(retweet)
                     )
-                   
+
         """
 
-        self.mentions = """UNWIND $mentions AS t                    
+        self.mentions = """UNWIND $mentions AS t
                     MATCH (tweet:Tweet {id:t.tweet_id})
-                    MERGE (user:Account {id:t.user_id})                    
-                        ON CREATE SET 
+                    MERGE (user:Account {id:t.user_id})
+                        ON CREATE SET
                             user.id = t.user_id,
                             user.mentioned_name = t.name,
                             user.mentioned_screen_name = t.user_screen_name,
                             user.record_created_at = timestamp(),
                             user.job_name = t.job_name,
                             user.job_id = t.job_id
-                    WITH user, tweet                                        
-                    MERGE (tweet)-[:MENTIONED]->(user)                  
+                    WITH user, tweet
+                    MERGE (tweet)-[:MENTIONED]->(user)
         """
 
-        self.urls = """UNWIND $urls AS t                    
+        self.urls = """UNWIND $urls AS t
                     MATCH (tweet:Tweet {id:t.tweet_id})
-                    MERGE (url:Url {full_url:t.url})                    
-                        ON CREATE SET 
+                    MERGE (url:Url {full_url:t.url})
+                        ON CREATE SET
                             url.full_url = t.url,
                             url.job_name = t.job_name,
                             url.job_id = t.job_id,
                             url.record_created_at = timestamp(),
-                            url.schema=t.scheme,   
-                            url.netloc=t.netloc,   
-                            url.path=t.path,   
-                            url.params=t.params,   
-                            url.query=t.query,       
-                            url.fragment=t.fragment,       
-                            url.username=t.username,       
-                            url.password=t.password,       
-                            url.hostname=t.hostname,      
+                            url.schema=t.scheme,
+                            url.netloc=t.netloc,
+                            url.path=t.path,
+                            url.params=t.params,
+                            url.query=t.query,
+                            url.fragment=t.fragment,
+                            url.username=t.username,
+                            url.password=t.password,
+                            url.hostname=t.hostname,
                             url.port=t.port
-                    WITH url, tweet                                        
-                    MERGE (tweet)-[:INCLUDES]->(url)                  
+                    WITH url, tweet
+                    MERGE (tweet)-[:INCLUDES]->(url)
         """
 
-        self.fetch_tweet_status = """UNWIND $ids AS i                    
+        self.fetch_tweet_status = """UNWIND $ids AS i
                     MATCH (tweet:Tweet {id:i.id})
                     RETURN tweet.id, tweet.hydrated
         """
 
-        self.fetch_tweet = """UNWIND $ids AS i                    
+        self.fetch_tweet = """UNWIND $ids AS i
                     MATCH (tweet:Tweet {id:i.id})
                     RETURN tweet
         """
@@ -193,18 +210,25 @@ class Neo4jDataAccess:
             self.graph = None
         return self.graph
 
-    def get_from_neo(self, cypher, limit=1000):
+    def get_neo4j_graph(self, role_type: RoleType):
+        if not isinstance(role_type, self.RoleType):
+            raise TypeError('The role_type parameter is not of type RoleType')
+        return self.__get_neo4j_graph(role_type.value)
+
+    def get_from_neo(self, cypher: str, limit=1000):
         graph = self.__get_neo4j_graph('reader')
-        # If the limit isn't set in the traversal then add it
-        if not re.search('LIMIT', cypher, re.IGNORECASE):
+        # If the limit isn't set in the traversal, and it isn't None, then add it
+        if limit and not re.search('LIMIT', cypher, re.IGNORECASE):
             cypher = cypher + " LIMIT " + str(limit)
         with graph.session() as session:
             result = session.run(cypher, timeout=self.timeout)
             df = pd.DataFrame([dict(record) for record in result])
-        rdf = df.head(limit)
-        return rdf
+        if not limit:
+            return df
+        else:
+            return df.head(limit)
 
-    def get_tweet_by_id(self, df, cols=[]):
+    def get_tweet_by_id(self, df: pd.DataFrame, cols=[]):
         if 'id' in df:
             graph = self.__get_neo4j_graph('reader')
             ids = []
@@ -228,17 +252,41 @@ class Neo4jDataAccess:
                 pdf = pdf.append(props, ignore_index=True)
             return pdf
         else:
-            logging.debug('df columns %s', df.columns)
-            raise Exception(
+            raise TypeError(
                 'Parameter df must be a DataFrame with a column named "id" ')
 
-    def save_parquet_df_to_graph(self, df, job_name, job_id=None):
+    def save_enrichment_df_to_graph(self, label: NodeLabel, df: pd.DataFrame, job_name: str, job_id=None):
+        if not isinstance(label, self.NodeLabel):
+            raise TypeError('The label parameter is not of type NodeType')
+
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(
+                'The df parameter is not of type Pandas.DataFrame')
+
+        idColName = 'full_url' if label == self.NodeLabel.Url else 'id'
+        statement = 'UNWIND $rows AS t'
+        statement += '   MERGE (n:' + label.value + \
+            ' {' + idColName + ':t.' + idColName + '}) ' + \
+            ' SET '
+
+        props = []
+        for column in df:
+            if not column == idColName:
+                props.append(f' n.{column} = t.{column} ')
+
+        statement += ','.join(props)
+        graph = self.__get_neo4j_graph('writer')
+        with graph.session() as session:
+            result = session.run(
+                statement, rows=df.to_dict(orient='records'), timeout=self.timeout)
+
+    def save_parquet_df_to_graph(self, df: pd.DataFrame, job_name: str, job_id=None):
         pdf = DfHelper().normalize_parquet_dataframe(df)
         logging.info('Saving to Neo4j')
         self.__save_df_to_graph(pdf, job_name)
 
     # Get the status of a DataFrame of Tweets by id.  Returns a dataframe with the hydrated status
-    def get_tweet_hydrated_status_by_id(self, df):
+    def get_tweet_hydrated_status_by_id(self, df: pd.DataFrame):
         if 'id' in df:
             graph = self.__get_neo4j_graph('reader')
             ids = []

--- a/modules/Neo4jDataAccess.py
+++ b/modules/Neo4jDataAccess.py
@@ -3,35 +3,18 @@ import json
 import time
 import re
 
-import enum
-
 from datetime import datetime
 import pandas as pd
 from neo4j import GraphDatabase, basic_auth
 from urllib.parse import urlparse
 import logging
+
 from .DfHelper import DfHelper
 
 logger = logging.getLogger('Neo4jDataAccess')
 
 
 class Neo4jDataAccess:
-    class NodeLabel(enum.Enum):
-        Tweet = 'Tweet'
-        Url = 'Url'
-        Account = 'Account'
-
-    class RelationshipLabel(enum.Enum):
-        TWEETED = 'TWEETED'
-        MENTIONED = 'MENTIONED'
-        QUOTED = 'QUOTED'
-        REPLIED = 'REPLIED'
-        RETWEETED = 'RETWEETED'
-        INCLUDES = 'INCLUDES'
-
-    class RoleType(enum.Enum):
-        READER = 'reader'
-        WRITER = 'writer'
 
     def __init__(self, debug=False, neo4j_creds=None, batch_size=2000, timeout="60s"):
         self.creds = neo4j_creds
@@ -40,9 +23,9 @@ class Neo4jDataAccess:
         self.batch_size = batch_size
         self.tweetsandaccounts = """
                   UNWIND $tweets AS t
-                      //Add the Tweet
+                      //Add the Tweet 
                     MERGE (tweet:Tweet {id:t.tweet_id})
-                        ON CREATE SET
+                        ON CREATE SET 
                             tweet.text = t.text,
                             tweet.created_at = t.tweet_created_at,
                             tweet.favorite_count = t.favorite_count,
@@ -53,7 +36,7 @@ class Neo4jDataAccess:
                             tweet.hashtags = t.hashtags,
                             tweet.hydrated = 'FULL',
                             tweet.type = t.tweet_type
-                        ON MATCH SET
+                        ON MATCH SET 
                             tweet.text = t.text,
                             tweet.favorite_count = t.favorite_count,
                             tweet.retweet_count = t.retweet_count,
@@ -63,10 +46,10 @@ class Neo4jDataAccess:
                             tweet.hashtags = t.hashtags,
                             tweet.hydrated = 'FULL',
                             tweet.type = t.tweet_type
-
+                    
                     //Add Account
-                    MERGE (user:Account {id:t.user_id})
-                        ON CREATE SET
+                    MERGE (user:Account {id:t.user_id})                    
+                        ON CREATE SET 
                             user.id = t.user_id,
                             user.name = t.name,
                             user.screen_name = t.user_screen_name,
@@ -78,7 +61,7 @@ class Neo4jDataAccess:
                             user.record_created_at = timestamp(),
                             user.job_name = t.job_name,
                             user.job_id = t.job_id
-                        ON MATCH SET
+                        ON MATCH SET 
                             user.name = t.user_name,
                             user.screen_name = t.user_screen_name,
                             user.followers_count = t.user_followers_count,
@@ -88,31 +71,31 @@ class Neo4jDataAccess:
                             user.created_at = t.user_created_at,
                             user.record_updated_at = timestamp(),
                             user.job_name = t.job_name,
-                            user.job_id = t.job_id
+                            user.job_id = t.job_id                  
 
                     //Add Reply to tweets if needed
-                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='REPLY' THEN [1] ELSE [] END |
-                        MERGE (retweet:Tweet {id:t.reply_tweet_id})
+                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='REPLY' THEN [1] ELSE [] END | 
+                        MERGE (retweet:Tweet {id:t.reply_tweet_id})            
                             ON CREATE SET retweet.id=t.reply_tweet_id,
                             retweet.record_created_at = timestamp(),
                             retweet.job_name = t.job_name,
                             retweet.job_id = t.job_id,
                             retweet.hydrated = 'PARTIAL'
                     )
-
+                    
                     //Add QUOTE_RETWEET to tweets if needed
-                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='QUOTE_RETWEET' THEN [1] ELSE [] END |
-                        MERGE (quoteTweet:Tweet {id:t.quoted_status_id})
+                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='QUOTE_RETWEET' THEN [1] ELSE [] END | 
+                        MERGE (quoteTweet:Tweet {id:t.quoted_status_id})            
                             ON CREATE SET quoteTweet.id=t.quoted_status_id,
                             quoteTweet.record_created_at = timestamp(),
                             quoteTweet.job_name = t.job_name,
                             quoteTweet.job_id = t.job_id,
                             quoteTweet.hydrated = 'PARTIAL'
                     )
-
+                    
                     //Add RETWEET to tweets if needed
-                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='RETWEET' THEN [1] ELSE [] END |
-                        MERGE (retweet:Tweet {id:t.retweet_id})
+                    FOREACH(ignoreMe IN CASE WHEN t.tweet_type='RETWEET' THEN [1] ELSE [] END | 
+                        MERGE (retweet:Tweet {id:t.retweet_id})            
                             ON CREATE SET retweet.id=t.retweet_id,
                             retweet.record_created_at = timestamp(),
                             retweet.job_name = t.job_name,
@@ -123,70 +106,70 @@ class Neo4jDataAccess:
 
         self.tweeted_rel = """UNWIND $tweets AS t
                     MATCH (user:Account {id:t.user_id})
-                    MATCH (tweet:Tweet {id:t.tweet_id})
-                    OPTIONAL MATCH (replied:Tweet {id:t.reply_tweet_id})
-                    OPTIONAL MATCH (quoteTweet:Tweet {id:t.quoted_status_id})
-                    OPTIONAL MATCH (retweet:Tweet {id:t.retweet_id})
+                    MATCH (tweet:Tweet {id:t.tweet_id})  
+                    OPTIONAL MATCH (replied:Tweet {id:t.reply_tweet_id})     
+                    OPTIONAL MATCH (quoteTweet:Tweet {id:t.quoted_status_id})    
+                    OPTIONAL MATCH (retweet:Tweet {id:t.retweet_id})   
                     WITH user, tweet, replied, quoteTweet, retweet
-
+                                        
                     MERGE (user)-[r:TWEETED]->(tweet)
-
-                    FOREACH(ignoreMe IN CASE WHEN tweet.type='REPLY' AND replied.id>0 THEN [1] ELSE [] END |
+                    
+                    FOREACH(ignoreMe IN CASE WHEN tweet.type='REPLY' AND replied.id>0 THEN [1] ELSE [] END | 
                         MERGE (tweet)-[:REPLYED]->(replied)
                     )
-
-                    FOREACH(ignoreMe IN CASE WHEN tweet.type='QUOTE_RETWEET' AND quoteTweet.id>0 THEN [1] ELSE [] END |
+                    
+                    FOREACH(ignoreMe IN CASE WHEN tweet.type='QUOTE_RETWEET' AND quoteTweet.id>0 THEN [1] ELSE [] END | 
                         MERGE (tweet)-[:QUOTED]->(quoteTweet)
                     )
-
-                    FOREACH(ignoreMe IN CASE WHEN tweet.type='RETWEET' AND retweet.id>0 THEN [1] ELSE [] END |
+                    
+                    FOREACH(ignoreMe IN CASE WHEN tweet.type='RETWEET' AND retweet.id>0 THEN [1] ELSE [] END | 
                         MERGE (tweet)-[:RETWEETED]->(retweet)
                     )
-
+                   
         """
 
-        self.mentions = """UNWIND $mentions AS t
+        self.mentions = """UNWIND $mentions AS t                    
                     MATCH (tweet:Tweet {id:t.tweet_id})
-                    MERGE (user:Account {id:t.user_id})
-                        ON CREATE SET
+                    MERGE (user:Account {id:t.user_id})                    
+                        ON CREATE SET 
                             user.id = t.user_id,
                             user.mentioned_name = t.name,
                             user.mentioned_screen_name = t.user_screen_name,
                             user.record_created_at = timestamp(),
                             user.job_name = t.job_name,
                             user.job_id = t.job_id
-                    WITH user, tweet
-                    MERGE (tweet)-[:MENTIONED]->(user)
+                    WITH user, tweet                                        
+                    MERGE (tweet)-[:MENTIONED]->(user)                  
         """
 
-        self.urls = """UNWIND $urls AS t
+        self.urls = """UNWIND $urls AS t                    
                     MATCH (tweet:Tweet {id:t.tweet_id})
-                    MERGE (url:Url {full_url:t.url})
-                        ON CREATE SET
+                    MERGE (url:Url {full_url:t.url})                    
+                        ON CREATE SET 
                             url.full_url = t.url,
                             url.job_name = t.job_name,
                             url.job_id = t.job_id,
                             url.record_created_at = timestamp(),
-                            url.schema=t.scheme,
-                            url.netloc=t.netloc,
-                            url.path=t.path,
-                            url.params=t.params,
-                            url.query=t.query,
-                            url.fragment=t.fragment,
-                            url.username=t.username,
-                            url.password=t.password,
-                            url.hostname=t.hostname,
+                            url.schema=t.scheme,   
+                            url.netloc=t.netloc,   
+                            url.path=t.path,   
+                            url.params=t.params,   
+                            url.query=t.query,       
+                            url.fragment=t.fragment,       
+                            url.username=t.username,       
+                            url.password=t.password,       
+                            url.hostname=t.hostname,      
                             url.port=t.port
-                    WITH url, tweet
-                    MERGE (tweet)-[:INCLUDES]->(url)
+                    WITH url, tweet                                        
+                    MERGE (tweet)-[:INCLUDES]->(url)                  
         """
 
-        self.fetch_tweet_status = """UNWIND $ids AS i
+        self.fetch_tweet_status = """UNWIND $ids AS i                    
                     MATCH (tweet:Tweet {id:i.id})
                     RETURN tweet.id, tweet.hydrated
         """
 
-        self.fetch_tweet = """UNWIND $ids AS i
+        self.fetch_tweet = """UNWIND $ids AS i                    
                     MATCH (tweet:Tweet {id:i.id})
                     RETURN tweet
         """
@@ -210,25 +193,18 @@ class Neo4jDataAccess:
             self.graph = None
         return self.graph
 
-    def get_neo4j_graph(self, role_type: RoleType):
-        if not isinstance(role_type, self.RoleType):
-            raise TypeError('The role_type parameter is not of type RoleType')
-        return self.__get_neo4j_graph(role_type.value)
-
-    def get_from_neo(self, cypher: str, limit=1000):
+    def get_from_neo(self, cypher, limit=1000):
         graph = self.__get_neo4j_graph('reader')
-        # If the limit isn't set in the traversal, and it isn't None, then add it
-        if limit and not re.search('LIMIT', cypher, re.IGNORECASE):
+        # If the limit isn't set in the traversal then add it
+        if not re.search('LIMIT', cypher, re.IGNORECASE):
             cypher = cypher + " LIMIT " + str(limit)
         with graph.session() as session:
             result = session.run(cypher, timeout=self.timeout)
             df = pd.DataFrame([dict(record) for record in result])
-        if not limit:
-            return df
-        else:
-            return df.head(limit)
+        rdf = df.head(limit)
+        return rdf
 
-    def get_tweet_by_id(self, df: pd.DataFrame, cols=[]):
+    def get_tweet_by_id(self, df, cols=[]):
         if 'id' in df:
             graph = self.__get_neo4j_graph('reader')
             ids = []
@@ -252,41 +228,17 @@ class Neo4jDataAccess:
                 pdf = pdf.append(props, ignore_index=True)
             return pdf
         else:
-            raise TypeError(
+            logging.debug('df columns %s', df.columns)
+            raise Exception(
                 'Parameter df must be a DataFrame with a column named "id" ')
 
-    def save_enrichment_df_to_graph(self, label: NodeLabel, df: pd.DataFrame, job_name: str, job_id=None):
-        if not isinstance(label, self.NodeLabel):
-            raise TypeError('The label parameter is not of type NodeType')
-
-        if not isinstance(df, pd.DataFrame):
-            raise TypeError(
-                'The df parameter is not of type Pandas.DataFrame')
-
-        idColName = 'full_url' if label == self.NodeLabel.Url else 'id'
-        statement = 'UNWIND $rows AS t'
-        statement += '   MERGE (n:' + label.value + \
-            ' {' + idColName + ':t.' + idColName + '}) ' + \
-            ' SET '
-
-        props = []
-        for column in df:
-            if not column == idColName:
-                props.append(f' n.{column} = t.{column} ')
-
-        statement += ','.join(props)
-        graph = self.__get_neo4j_graph('writer')
-        with graph.session() as session:
-            result = session.run(
-                statement, rows=df.to_dict(orient='records'), timeout=self.timeout)
-
-    def save_parquet_df_to_graph(self, df: pd.DataFrame, job_name: str, job_id=None):
+    def save_parquet_df_to_graph(self, df, job_name, job_id=None):
         pdf = DfHelper().normalize_parquet_dataframe(df)
         logging.info('Saving to Neo4j')
         self.__save_df_to_graph(pdf, job_name)
 
     # Get the status of a DataFrame of Tweets by id.  Returns a dataframe with the hydrated status
-    def get_tweet_hydrated_status_by_id(self, df: pd.DataFrame):
+    def get_tweet_hydrated_status_by_id(self, df):
         if 'id' in df:
             graph = self.__get_neo4j_graph('reader')
             ids = []
@@ -322,7 +274,9 @@ class Neo4jDataAccess:
         for index, row in df.iterrows():
             # determine the type of tweet
             tweet_type = 'TWEET'
-            if row["in_reply_to_status_id"] is not None and row["in_reply_to_status_id"] > 0:
+            if row['tweet_type_twint']:
+                tweet_type = row['tweet_type_twint']
+            elif row["in_reply_to_status_id"] is not None and row["in_reply_to_status_id"] > 0:
                 tweet_type = "REPLY"
             elif "quoted_status_id" in row and row["quoted_status_id"] is not None and row["quoted_status_id"] > 0:
                 tweet_type = "QUOTE_RETWEET"
@@ -347,8 +301,10 @@ class Neo4jDataAccess:
                                'user_created_at': pd.Timestamp(row['user_created_at'], unit='s').to_pydatetime(),
                                'user_profile_image_url': row['user_profile_image_url'],
                                'reply_tweet_id': row['in_reply_to_status_id'],
+                               'conversation_id': row['conversation_id'] if 'conversation_id' in row else None,
                                'quoted_status_id': row['quoted_status_id'],
                                'retweet_id': row['retweet_id'] if 'retweet_id' in row else None,
+                               'geo': row['geo'] if 'geo' in row else None,
                                })
             except Exception as e:
                 logging.error('params.append exn', e)

--- a/modules/Neo4jDataAccess.py
+++ b/modules/Neo4jDataAccess.py
@@ -353,6 +353,7 @@ class Neo4jDataAccess:
                                'quoted_status_id': row['quoted_status_id'],
                                'retweet_id': row['retweet_id'] if 'retweet_id' in row else None,
                                'geo': row['geo'] if 'geo' in row else None,
+                               'ingest_method': row['ingest_method']
                                })
             except Exception as e:
                 logging.error('params.append exn', e)

--- a/modules/Twint.py
+++ b/modules/Twint.py
@@ -1,0 +1,112 @@
+import pyarrow as pa
+import twint
+from urlextract import URLExtractor
+from datetime import datetime, timedelta
+
+
+class TwintPool:
+    def __init__(self, fh_job=None, job_name="noname"):
+        self.fh = fh_job
+        self.config = twint.Config()
+        self.config.Limit = 100
+        self.config.Pandas = True
+        self.config.User_full = True
+        self.config.Hide_output = True
+
+    def twint_loop(self, since, until, stride_sec=600, limit=None):
+        def get_unix_time(time_str):
+            return datetime.strptime(time_str, "%Y-%m-%d %H:%M:%S")
+
+        since = get_unix_time(since)
+        until = get_unix_time(until)
+        t = since
+        tweets_returned = 0
+
+        while t < until and (not tweets_returned or tweets_returned < limit):
+            t0 = t
+            t1 = t + timedelta(seconds=stride_sec)
+            self.config.Since = str(t0)
+            self.config.Until = str(t1)
+            twint.run.Search(self.config)
+            tweets_returned += len(twint.storage.panda.Tweets_df)
+            yield (twint.storage.panda.Tweets_df, t0, t1)
+            t = t1
+
+    def _get_term(
+        self,
+        Search="IngSoc",
+        Since="1984-04-20 13:00:00",
+        Until="1984-04-20 13:30:00",
+        stride_sec=600,
+        **kwargs
+    ):
+        self.config.Search = Search
+        self.config.Retweets = True
+        for k, v in kwargs.items():
+            setattr(self.config, k, v)
+        # self.config.Search = term
+        for df, t0, t1 in self.twint_loop(Since, Until, stride_sec, self.config.Limit):
+            yield (df, t0, t1)
+
+    def _get_timeline(self, username="lmeyerov"):
+        self.config.Username = username
+        self.config.Retweets = True
+        # self.config.Search = term
+        twint.run.Profile(self.config)
+        tweets_df = twint.storage.panda.Tweets_df
+        return tweets_df
+
+    def twint_df_to_neo4j_df(self, df):
+        neo4j_df = df.rename(
+            columns={
+                "id": "status_id",
+                "tweet": "full_text",
+                "created_at": "created_at",  # needs to be datetime
+                "nlikes": "favorite_count",
+                "nretweets": "retweet_count",
+                "user_id_str": "user_id",
+                "username": "user_name",
+                "name": "user_screen_name",
+            }
+        )
+
+        def row_to_tweet_type(row):
+            if row["quote_url"] is None or row["quote_url"] == "":
+                return "QUOTE_RETWEET"
+            elif row["retweet"]:
+                return "RETWEET"
+            elif row["id"] == row["conversation_id"]:
+                return "TWEET"
+            elif row["id"] != row["conversation_id"]:
+                return "REPLY"
+            else:
+                raise ("wat")
+
+        def row_to_quoted_status_id(row):
+            if row["quote_url"] and len(row["quote_url"]) > 0:
+                return row["quote_url"].split("/")[-1]
+            else:
+                return None
+
+        def row_tweet_to_urls(row):
+            extractor = URLExtract()
+            return list(extractor.gen_urls(row["tweet"]))
+
+        neo4j_df["user_location"] = None
+        neo4j_df["tweet_type_twint"] = df.apply(row_to_tweet_type, axis=1)
+        neo4j_df["hashtags"] = df["hashtags"].apply(
+            lambda x: [{"text": ht} for ht in x]
+        )
+        neo4j_df["user_followers_count"] = None
+        neo4j_df["user_friends_count"] = None
+        neo4j_df["user_created_at"] = None
+        neo4j_df["user_profile_image_url"] = None
+        neo4j_df["reply_tweet_id"] = None
+        neo4j_df["user_mentions"] = []  # Todo
+        # neo4j_df['retweet_id'] is suspiciously empty (always)
+
+        neo4j_df["quoted_status_id"] = df.apply(row_to_quoted_status_id, axis=1)
+        neo4j_df["urls"] = df.apply(row_tweet_to_urls, axis=1)
+
+    def to_arrow(self, tweets_df):
+        pass

--- a/modules/Twint.py
+++ b/modules/Twint.py
@@ -108,5 +108,9 @@ class TwintPool:
         neo4j_df["quoted_status_id"] = df.apply(row_to_quoted_status_id, axis=1)
         neo4j_df["urls"] = df.apply(row_tweet_to_urls, axis=1)
 
+        neo4j_df["ingest_method"] = 'twint'
+
+        return neo4j_df
+
     def to_arrow(self, tweets_df):
         pass

--- a/modules/Twint.py
+++ b/modules/Twint.py
@@ -101,7 +101,7 @@ class TwintPool:
         neo4j_df["user_friends_count"] = None
         neo4j_df["user_created_at"] = None
         neo4j_df["user_profile_image_url"] = None
-        neo4j_df["reply_tweet_id"] = None
+        neo4j_df["in_reply_to_status_id"] = None
         neo4j_df["user_mentions"] = []  # Todo
         # neo4j_df['retweet_id'] is suspiciously empty (always)
 

--- a/modules/Twint.py
+++ b/modules/Twint.py
@@ -48,11 +48,12 @@ class TwintPool:
         for df, t0, t1 in self.twint_loop(Since, Until, stride_sec, self.config.Limit):
             yield (df, t0, t1)
 
+    
     def _get_timeline(self, username="lmeyerov"):
         self.config.Username = username
         self.config.Retweets = True
-        # self.config.Search = term
-        twint.run.Profile(self.config)
+        #self.config.Search = term
+        twint.run.Search(self.config)
         tweets_df = twint.storage.panda.Tweets_df
         return tweets_df
 


### PR DESCRIPTION
This begins the integration of Twint data to the dataframe format required for storing of tweets into Neo4j.

A few key differences from Twarc and other details:

- search proceeds by terms or for user's timeline (with options for geofencing) `twint.run.Search()`
- user details need to be separately fetched through a separate call to `twint.run.Followers()` and `twint.run.Lookup()`
- the search for terms is an AND and is not performed asynchronously - multiple Prefect jobs will be required for multiple terms (and a separate job to enrich profile details)

@lmeyerov and I spent some time to get the fields from the Twint df to line up with that what we were getting from Twarc, but work remains on integrating several additional fields (see https://github.com/TheDataRideAlongs/ProjectDomino/blob/twint/modules/Twint.py#L59)

Of note are: `user_mentions`, `retweet_id`, `in_reply_to_status_id`.

Consequently, `twint` is designed to generate tweets based on Since and Until timestamps (with granularity down to a second) and can operate as a streaming mechanism, whereas `twarc` can be preserved for historic pulls by id.